### PR TITLE
Fix definition typos

### DIFF
--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -829,7 +829,7 @@ class PlatformAutoGen(AutoGen):
                 RetVal = RetVal + _SplitOption(Flags.strip())
         return RetVal
 
-    ## Compute a tool defintion key priority value in range 0..15
+    ## Compute a tool definition key priority value in range 0..15
     #
     #  TARGET_TOOLCHAIN_ARCH_COMMANDTYPE_ATTRIBUTE  15
     #  ******_TOOLCHAIN_ARCH_COMMANDTYPE_ATTRIBUTE  14

--- a/DynamicTablesPkg/Library/Common/AmlLib/Parser/AmlMethodParser.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/Parser/AmlMethodParser.c
@@ -915,7 +915,7 @@ AmlFindMethodDefinition (
                  ))
     {
       // The path matches an alias. Resolve the alias and check whether
-      // this is a method defintion.
+      // this is a method definition.
       Status = AmlResolveAliasMethod (
                  BestNameSpaceRefNode->NodeRef,
                  NameSpaceRefList,

--- a/EmulatorPkg/BootModePei/BootModePei.c
+++ b/EmulatorPkg/BootModePei/BootModePei.c
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 
 //
-// The protocols, PPI and GUID defintions for this module
+// The protocols, PPI and GUID definitions for this module
 //
 #include <Ppi/MasterBootMode.h>
 #include <Ppi/BootInRecoveryMode.h>

--- a/MdeModulePkg/Bus/Pci/UhciDxe/Uhci.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/Uhci.c
@@ -875,7 +875,7 @@ Uhci2BulkTransfer (
 
   //
   // Link the TDs to bulk queue head. According to the platfore
-  // defintion of UHCI_NO_BW_RECLAMATION, BulkQh is either configured
+  // definition of UHCI_NO_BW_RECLAMATION, BulkQh is either configured
   // to do full speed bandwidth reclamation or not.
   //
   BulkQh = Uhc->BulkQh;

--- a/MdeModulePkg/Include/Library/SecurityManagementLib.h
+++ b/MdeModulePkg/Include/Library/SecurityManagementLib.h
@@ -12,7 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define __SECURITY_MANAGEMENT_LIB_H__
 
 //
-// Authentication Operation defintions for User Identity (UID), Measured and Secure boot.
+// Authentication Operation definitions for User Identity (UID), Measured and Secure boot.
 //
 #define EFI_AUTH_OPERATION_NONE              0x00
 #define EFI_AUTH_OPERATION_VERIFY_IMAGE      0x01

--- a/MdeModulePkg/Universal/CapsuleOnDiskLoadPei/CapsuleOnDiskLoadPei.c
+++ b/MdeModulePkg/Universal/CapsuleOnDiskLoadPei/CapsuleOnDiskLoadPei.c
@@ -20,7 +20,7 @@
 #include <PiPei.h>
 
 //
-// The protocols, PPI and GUID defintions for this module
+// The protocols, PPI and GUID definitions for this module
 //
 #include <Ppi/MasterBootMode.h>
 #include <Ppi/FirmwareVolumeInfo.h>

--- a/MdeModulePkg/Universal/PlatformDriOverrideDxe/PlatOverMngr.h
+++ b/MdeModulePkg/Universal/PlatformDriOverrideDxe/PlatOverMngr.h
@@ -1,6 +1,6 @@
 /** @file
 
-  The defintions are required both by Source code and Vfr file.
+  The definitions are required both by Source code and Vfr file.
   The PLAT_OVER_MNGR_DATA structure, form guid and Ifr question ID are defined.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>

--- a/MdePkg/Include/IndustryStandard/ArmErrorSourceTable.h
+++ b/MdePkg/Include/IndustryStandard/ArmErrorSourceTable.h
@@ -161,11 +161,11 @@ typedef struct {
   UINT8     Reserved1[3];
 } EFI_ACPI_AEST_INTERRUPT_STRUCT;
 
-// AEST Interrupt node - interrupt type defintions.
+// AEST Interrupt node - interrupt type definitions.
 #define EFI_ACPI_AEST_INTERRUPT_TYPE_FAULT_HANDLING  0x0
 #define EFI_ACPI_AEST_INTERRUPT_TYPE_ERROR_RECOVERY  0x1
 
-// AEST Interrupt node - interrupt flag defintions.
+// AEST Interrupt node - interrupt flag definitions.
 #define EFI_ACPI_AEST_INTERRUPT_FLAG_TRIGGER_TYPE_EDGE   0
 #define EFI_ACPI_AEST_INTERRUPT_FLAG_TRIGGER_TYPE_LEVEL  BIT0
 

--- a/MdePkg/Include/Pi/PiPeiCis.h
+++ b/MdePkg/Include/Pi/PiPeiCis.h
@@ -859,7 +859,7 @@ EFI_STATUS
 #define PEI_SERVICES_SIGNATURE  0x5652455320494550ULL
 ///
 /// Specification inconsistency here:
-/// In the PI1.0 specification, there is a typo error in PEI_SERVICES_REVISION. In the specification the defintion is
+/// In the PI1.0 specification, there is a typo error in PEI_SERVICES_REVISION. In the specification the definition is
 /// #define ((PEI_SPECIFICATION_MAJOR_REVISION<<16) |(PEI_SPECIFICATION_MINOR_REVISION))
 /// and it should be as follows:
 ///

--- a/MdePkg/Include/Pi/PiS3BootScript.h
+++ b/MdePkg/Include/Pi/PiS3BootScript.h
@@ -1,5 +1,5 @@
 /** @file
-  This file contains the boot script defintions that are shared between the
+  This file contains the boot script definitions that are shared between the
   Boot Script Executor PPI and the Boot Script Save Protocol.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>

--- a/MdePkg/Include/Protocol/PxeBaseCodeCallBack.h
+++ b/MdePkg/Include/Protocol/PxeBaseCodeCallBack.h
@@ -27,7 +27,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_REVISION  0x00010000
 
 ///
-/// EFI 1.1 Revision Number defintion.
+/// EFI 1.1 Revision Number definition.
 ///
 #define EFI_PXE_BASE_CODE_CALLBACK_INTERFACE_REVISION  \
         EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_REVISION

--- a/MdePkg/Include/Protocol/RestJsonStructure.h
+++ b/MdePkg/Include/Protocol/RestJsonStructure.h
@@ -25,7 +25,7 @@ typedef struct _EFI_REST_JSON_STRUCTURE_PROTOCOL  EFI_REST_JSON_STRUCTURE_PROTOC
 typedef CHAR8                                     *EFI_REST_JSON_RESOURCE_TYPE_DATATYPE;
 
 ///
-/// Structure defintions of resource name space.
+/// Structure definitions of resource name space.
 ///
 /// The fields declared in this structure define the
 /// name and revision of payload delievered throught

--- a/MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLibInternals.h
+++ b/MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLibInternals.h
@@ -1,5 +1,5 @@
 /** @file
-  Internal data structure defintions for Base UEFI Decompress Library.
+  Internal data structure definitions for Base UEFI Decompress Library.
 
   Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -75,7 +75,7 @@
   ##  @libraryclass  Module entry point library for UEFI drivers, DXE Drivers, DXE SMM Driver and DXE Runtime Drivers
   UefiDriverEntryPoint|Include/Library/UefiDriverEntryPoint.h
 
-  ##  @libraryclass  UEFI Decompress Library Functions defintion for UEFI compress algorithm.
+  ##  @libraryclass  UEFI Decompress Library Functions definition for UEFI compress algorithm.
   UefiDecompressLib|Include/Library/UefiDecompressLib.h
 
   ##  @libraryclass  Provides a service to retrieve a pointer to the EFI Boot Services Table.

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -758,7 +758,7 @@ MOCK_FUNCTION_DEFINITION(MockUefiLib, GetVariable2, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION(MockUefiLib, GetEfiGlobalVariable2, 3, EFIAPI);
 ```
 
-When creating the defintions, there are a few things to keep in mind.
+When creating the definitions, there are a few things to keep in mind.
 
 First, when using `MOCK_FUNCTION_DEFINITION`, some functions being mocked do
 not specify a calling convention. In this case, it is fine to leave the last


### PR DESCRIPTION
## Summary
- fix various `defintion` typos in comments and docs

## Testing
- `python3 -m unittest discover -s ./BaseTools/Plugin/DebugMacroCheck/tests -v` *(fails: ModuleNotFoundError: No module named 'regex')*

------
https://chatgpt.com/codex/tasks/task_e_684162554d388331870cf9fd9e107779