### PR TITLE
LoongArchVirt: enable TPM2 support

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -131,11 +131,10 @@ Done:
   @retval EFI_SUCCESS     Initialize mPowerManager success.
   @retval EFI_NOT_FOUND   Failed to initialize mPowerManager.
 **/
-EFI_STATUS
+RETURN_STATUS
 EFIAPI
 ResetSystemLibConstructor (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+  VOID
   )
 {
   EFI_STATUS  Status;
@@ -149,5 +148,5 @@ ResetSystemLibConstructor (
   ASSERT (mPowerManager.SleepStatusRegAddr);
   ASSERT (mPowerManager.ResetRegAddr);
 
-  return Status;
+  return (RETURN_STATUS)Status;
 }

--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -131,7 +131,7 @@ Done:
   @retval EFI_NOT_FOUND   Failed to initialize mPowerManager.
 **/
 EFI_STATUS
-EFI_API
+EFIAPI
 ResetSystemLibConstructor (
   IN EFI_HANDLE        ImageHandle,
   IN EFI_SYSTEM_TABLE  *SystemTable

--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -7,6 +7,7 @@
 
 **/
 
+#include <IndustryStandard/Acpi.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/QemuFwCfgLib.h>

--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -7,6 +7,7 @@
 
 **/
 
+#include <PiDxe.h>
 #include <IndustryStandard/Acpi.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>

--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
@@ -8,6 +8,7 @@
 **/
 
 #include <Base.h>
+#include <IndustryStandard/Acpi.h>
 #include <Library/DebugLib.h>
 #include <Library/DxeServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -148,7 +148,16 @@
   SerializeVariablesLib            | OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   CustomizedDisplayLib             | MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   DebugPrintErrorLevelLib          | MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
-  TpmMeasurementLib                | MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+!if $(TPM2_ENABLE) == TRUE
+  Tpm2CommandLib                    | SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tcg2PhysicalPresenceLib           | OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
+  TpmMeasurementLib                 | SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
+  TpmPlatformHierarchyLib           | SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+!else
+  Tcg2PhysicalPresenceLib           | OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
+  TpmMeasurementLib                 | MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+  TpmPlatformHierarchyLib           | SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
+!endif
 !if $(SECURE_BOOT_ENABLE) == TRUE
   PlatformSecureLib                | OvmfPkg/Library/PlatformSecureLib/PlatformSecureLib.inf
   AuthVariableLib                  | SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
@@ -197,7 +206,6 @@
   PeCoffExtraActionLib             | MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf
   DebugAgentLib                    | MdeModulePkg/Library/DebugAgentLibNull/DebugAgentLibNull.inf
 
-  TpmPlatformHierarchyLib          | SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
   PlatformBmPrintScLib             | OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
   PlatformBootManagerLib           | OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBootManagerLib.inf
   BootLogoLib                      | MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -238,6 +246,10 @@
   PeCoffGetEntryPointLib           | MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   QemuFwCfgLib                     | OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioPeiLib.inf
   PlatformHookLib                  | OvmfPkg/LoongArchVirt/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  BaseCryptLib                     | CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  Tpm2DeviceLib                    | SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+!endif
 
 [LibraryClasses.common.PEIM]
   HobLib                           | MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -256,6 +268,10 @@
   CpuMmuInitLib                    | OvmfPkg/LoongArchVirt/Library/CpuMmuInitLib/CpuMmuInitLib.inf
   MpInitLib                        | UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
   PlatformHookLib                  | OvmfPkg/LoongArchVirt/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  BaseCryptLib                     | CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  Tpm2DeviceLib                    | SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+!endif
 
 [LibraryClasses.common.DXE_CORE]
   HobLib                           | MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
@@ -309,6 +325,9 @@
   PciPcdProducerLib                | OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   AcpiPlatformLib                  | OvmfPkg/Library/AcpiPlatformLib/DxeAcpiPlatformLib.inf
   MpInitLib                        | UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  Tpm2DeviceLib                    | SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
+!endif
 
 [LibraryClasses.common.UEFI_APPLICATION]
   PcdLib                           | MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -396,6 +415,11 @@
 !else
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask                        | 0x2f
 !endif
+!if $(TPM2_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                      | 0x0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                     | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask                        | 0
+!endif
 
 #######################################################################################
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase                  | $(SEC_PEI_TEMP_RAM_BASE)
@@ -468,9 +492,16 @@
 
 [PcdsDynamicHii]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|L"Timeout"|gEfiGlobalVariableGuid|0x0|3
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x8|3|NV,BS
+!endif
 
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x0
+!if $(TPM2_ENABLE) != TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x0
+!endif
 
 [Components]
 
@@ -497,6 +528,24 @@
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   }
+!if $(TPM2_ENABLE) == TRUE
+  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf {
+    <LibraryClasses>
+      Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+  }
+  SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf {
+    <LibraryClasses>
+      TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+  }
+!endif
 
   #
   # DXE Phase modules
@@ -699,6 +748,26 @@
   MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
   MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
   MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
+
+  #
+  # TPM2 support
+  #
+!if $(TPM2_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
+    <LibraryClasses>
+      HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
+      Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+  }
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+!endif
+!endif
 
   #
   # ACPI Support

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -415,10 +415,6 @@
 !else
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask                        | 0x2f
 !endif
-!if $(TPM2_ENABLE) == TRUE
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                      | 0x0
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                     | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-!endif
 
 #######################################################################################
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase                  | $(SEC_PEI_TEMP_RAM_BASE)
@@ -486,6 +482,8 @@
   # TPM2 support
   #
 !if $(TPM2_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                      | 0x0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                     | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask                        | 0
 !endif
 

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -418,7 +418,6 @@
 !if $(TPM2_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                      | 0x0
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                     | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask                        | 0
 !endif
 
 #######################################################################################
@@ -482,6 +481,13 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress                    |0xFFFFFFFFFFFFFFFF
 
 !include NetworkPkg/NetworkDynamicPcds.dsc.inc
+
+  #
+  # TPM2 support
+  #
+!if $(TPM2_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask                        | 0
+!endif
 
   #
   # SMBIOS entry point version

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -145,6 +145,16 @@ INF  MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
 INF  MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
 #
+# TPM2 support
+#
+!if $(TPM2_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+!endif
+!endif
+
+#
 #BDS
 #
 INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
@@ -231,6 +241,11 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+!if $(TPM2_ENABLE) == TRUE
+INF  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+INF  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+INF  SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
+!endif
 
 #
 # DXE Phase modules

--- a/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
@@ -19,6 +19,7 @@
 //
 #include <Guid/MemoryTypeInformation.h>
 #include <Guid/FdtHob.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/CpuMmuInitLib.h>
 #include <Library/DebugLib.h>
@@ -55,6 +56,20 @@ CONST EFI_PEI_PPI_DESCRIPTOR  mPpiListBootMode = {
   &gEfiPeiMasterBootModePpiGuid,
   NULL
 };
+
+#if TPM2_ENABLE
+CONST EFI_PEI_PPI_DESCRIPTOR  mTpm2DiscoveredPpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gOvmfTpmDiscoveredPpiGuid,
+  NULL
+};
+
+STATIC
+VOID
+SetupTpmResources (
+  CONST VOID  *Fdt
+  );
+#endif
 
 STATIC EFI_BOOT_MODE  mBootMode = BOOT_WITH_FULL_CONFIGURATION;
 
@@ -268,6 +283,10 @@ AddFdtHob (
   Base = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
   ASSERT (Base != NULL);
 
+#if TPM2_ENABLE
+  SetupTpmResources (Base);
+#endif
+
   Status = GetRtcAddress (Base, &RtcBaseAddress);
   if (RETURN_ERROR (Status)) {
     return;
@@ -363,3 +382,117 @@ InitializePlatform (
 
   return EFI_SUCCESS;
 }
+#if TPM2_ENABLE
+STATIC
+VOID
+SetupTpmResources (
+  CONST VOID  *Fdt
+  )
+{
+  INT32         Node;
+  INT32         Prev;
+  INT32         Parent;
+  INT32         Depth;
+  CONST CHAR8   *Compatible;
+  CONST CHAR8   *CompItem;
+  INT32         Len;
+  INT32         RangesLen;
+  CONST UINT8   *RegProp;
+  CONST UINT32  *RangesProp;
+  UINT64        TpmBase;
+  UINT64        TpmBaseSize;
+
+  if ((Fdt == NULL) || (FdtCheckHeader (Fdt) != 0)) {
+    return;
+  }
+
+  TpmBase     = 0;
+  TpmBaseSize = 0;
+  Parent      = 0;
+
+  for (Prev = Depth = 0; ; Prev = Node) {
+    Node = FdtNextNode (Fdt, Prev, &Depth);
+    if (Node < 0) {
+      break;
+    }
+
+    if (Depth == 1) {
+      Parent = Node;
+    }
+
+    Compatible = FdtGetProp (Fdt, Node, "compatible", &Len);
+    if (Compatible == NULL) {
+      continue;
+    }
+
+    for (CompItem = Compatible;
+         (CompItem != NULL) && (CompItem < Compatible + Len);
+         CompItem += 1 + AsciiStrLen (CompItem))
+    {
+      if (AsciiStrCmp (CompItem, "tcg,tpm-tis-mmio") != 0) {
+        continue;
+      }
+
+      RegProp = FdtGetProp (Fdt, Node, "reg", &Len);
+      if (RegProp == NULL) {
+        break;
+      }
+
+      if (Len == sizeof (UINT32) * 2) {
+        TpmBase     = Fdt32ToCpu (*(UINT32 *)RegProp);
+        TpmBaseSize = Fdt32ToCpu (*(UINT32 *)(RegProp + sizeof (UINT32)));
+      } else if (Len == sizeof (UINT64) * 2) {
+        TpmBase     = Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)RegProp));
+        TpmBaseSize = Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)(RegProp + sizeof (UINT64))));
+      } else {
+        DEBUG ((DEBUG_WARN, "%a: unexpected TPM 'reg' size %d\n", __func__, Len));
+        break;
+      }
+
+      if (Depth > 1) {
+        RangesProp = (CONST UINT32 *)FdtGetProp (Fdt, Parent, "ranges", &RangesLen);
+        if (RangesProp != NULL) {
+          if (RangesLen != 0) {
+            if (RangesLen != Len + 2 * sizeof (UINT32)) {
+              DEBUG ((
+                DEBUG_WARN,
+                "%a: 'ranges' property has unexpected size %d\n",
+                __func__,
+                RangesLen
+                ));
+              break;
+            }
+
+            if (Len == sizeof (UINT32) * 2) {
+              TpmBase -= Fdt32ToCpu (RangesProp[0]);
+            } else {
+              TpmBase -= Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)RangesProp));
+            }
+
+            RangesProp = (CONST UINT32 *)((CONST UINT8 *)RangesProp + Len / 2);
+            TpmBase   += Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)RangesProp));
+          }
+        }
+      }
+
+      break;
+    }
+  }
+
+  if (TpmBase != 0) {
+    BuildResourceDescriptorHob (
+      EFI_RESOURCE_MEMORY_MAPPED_IO,
+      EFI_RESOURCE_ATTRIBUTE_PRESENT     |
+      EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+      EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+      EFI_RESOURCE_ATTRIBUTE_TESTED,
+      TpmBase,
+      ALIGN_VALUE (TpmBaseSize, EFI_PAGE_SIZE)
+      );
+
+    ASSERT_EFI_ERROR ((EFI_STATUS)PcdSet64S (PcdTpmBaseAddress, TpmBase));
+    ASSERT_EFI_ERROR (PeiServicesInstallPpi (&mTpm2DiscoveredPpi));
+  }
+}
+#endif
+

--- a/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
@@ -33,6 +33,9 @@
 
 [Ppis]
   gEfiPeiMasterBootModePpiGuid
+!if $(TPM2_ENABLE) == TRUE
+  gOvmfTpmDiscoveredPpiGuid                                   ## SOMETIMES_PRODUCES
+!endif
 
 [Guids]
   gEfiMemoryTypeInformationGuid


### PR DESCRIPTION
## Summary
- add TPM 2.0 library mappings, PCDs, and conditional modules to the LoongArchVirt DSC so TPM2_ENABLE and TPM2_CONFIG_ENABLE provide full measurement and configuration flows
- include the corresponding Tcg2 PEI/DXE components in the LoongArchVirt firmware image layout

## Testing
- build -b RELEASE -t GCC5 -a LOONGARCH64 -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TRUE *(fails: BaseFdtLib dependency libfdt missing in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136345f2748331a66f602e0edabf25)