### PR TITLE
UsbBusDxe: retry EHCI enumeration timeouts before handoff

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -647,6 +647,73 @@ UsbFindChild (
 }
 
 /**
+  Free a partially enumerated device and release its bus slot.
+
+  This helper is only used when retrying enumeration on the root hub.
+
+  @param  Child                The USB device to free.
+**/
+STATIC
+VOID
+UsbCleanupEnumDevice (
+  IN USB_DEVICE  *Child
+  )
+{
+  USB_BUS  *Bus;
+
+  if (Child == NULL) {
+    return;
+  }
+
+  Bus = Child->Bus;
+
+  if (Child->DevDesc != NULL) {
+    UsbFreeDevDesc (Child->DevDesc);
+  }
+
+  if ((Child->Address != 0) && (Child->Address < Bus->MaxDevices) && (Bus->Devices[Child->Address] == Child)) {
+    Bus->Devices[Child->Address] = NULL;
+  }
+
+  UsbFreeDevice (Child);
+}
+
+/**
+  Toggle root port power to force a disconnect/reconnect sequence.
+
+  @param  HubIf                The root hub interface.
+  @param  Port                 The port to power cycle.
+
+  @retval EFI_SUCCESS          Port power was toggled.
+  @retval Others               Failed to toggle power.
+**/
+STATIC
+EFI_STATUS
+UsbRootHubPowerCyclePort (
+  IN USB_INTERFACE  *HubIf,
+  IN UINT8          Port
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = UsbRootHubClearPortFeature (HubIf, Port, EfiUsbPortPower);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  gBS->Stall (USB_SET_ROOT_PORT_RESET_STALL);
+
+  Status = UsbRootHubSetPortFeature (HubIf, Port, EfiUsbPortPower);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  gBS->Stall (USB_WAIT_PORT_STABLE_STALL);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Enumerate and configure the new device on the port of this HUB interface.
 
   @param  HubIf                 The HUB that has the device connected.
@@ -672,12 +739,17 @@ UsbEnumerateNewDev (
   EFI_USB_PORT_STATUS  PortState;
   UINTN                Address;
   UINT8                Config;
+  BOOLEAN              RetryPowerCycle;
   EFI_STATUS           Status;
+
+  RetryPowerCycle = FALSE;
 
   Parent  = HubIf->Device;
   Bus     = Parent->Bus;
   HubApi  = HubIf->HubApi;
+RetryEnum:
   Address = Bus->MaxDevices;
+  Child   = NULL;
 
   gBS->Stall (USB_WAIT_PORT_STABLE_STALL);
 
@@ -872,6 +944,30 @@ ON_ERROR:
   //
   // EDKII UHCI/EHCI doesn't get impacted as it's make sense to reserve s/w resource till it gets unplugged.
   //
+  if ((Status == EFI_TIMEOUT) && (HubIf->HubApi == &mUsbRootHubApi) && (HubIf->MaxSpeed == EFI_USB_SPEED_HIGH)) {
+    //
+    // EHCI-only recovery: power cycle once on timeout, then hand off to
+    // the companion controller if the retry also times out.
+    //
+    UsbCleanupEnumDevice (Child);
+
+    if (!RetryPowerCycle) {
+      RetryPowerCycle = TRUE;
+      ResetIsNeeded   = TRUE;
+
+      Status = UsbRootHubPowerCyclePort (HubIf, Port);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: port %d power cycle failed - %r\n", Port, Status));
+      } else {
+        DEBUG ((DEBUG_WARN, "UsbEnumerateNewDev: retry enumeration on port %d after timeout\n", Port));
+        goto RetryEnum;
+      }
+    }
+
+    UsbRootHubSetPortFeature (HubIf, Port, EfiUsbPortOwner);
+    Status = EFI_NOT_FOUND;
+  }
+
   return Status;
 }
 


### PR DESCRIPTION
## Summary
- add helpers to clean up failed enumeration attempts and power-cycle EHCI root ports
- retry enumeration once after control-transfer timeouts before handing the port to a companion controller

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69080542460c8331993ff89d5cc9e13a)