### PR TITLE
Mnp: refresh RX buffer pool after SNP initialization

### DIFF
--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -38,6 +38,81 @@ EFI_MANAGED_NETWORK_CONFIG_DATA  mMnpDefaultConfigData = {
   FALSE
 };
 
+STATIC
+UINT32
+MnpCalculateBufferLength (
+  IN EFI_SIMPLE_NETWORK_MODE  *SnpMode
+  )
+{
+  return SnpMode->MediaHeaderSize + NET_VLAN_TAG_LEN + SnpMode->MaxPacketSize + NET_ETHER_FCS_SIZE;
+}
+
+STATIC
+UINT32
+MnpCalculatePaddingSize (
+  IN EFI_SIMPLE_NETWORK_MODE  *SnpMode
+  )
+{
+  //
+  // Make sure the protocol headers immediately following the media header
+  // 4-byte aligned, and also preserve additional space for VLAN tag.
+  //
+  return ((4 - SnpMode->MediaHeaderSize) & 0x3) + NET_VLAN_TAG_LEN;
+}
+
+STATIC
+EFI_STATUS
+MnpRefreshBufferPool (
+  IN OUT MNP_DEVICE_DATA  *MnpDeviceData
+  )
+{
+  EFI_SIMPLE_NETWORK_MODE  *SnpMode;
+  UINT32                   NewBufferLength;
+  UINT32                   NewPaddingSize;
+  EFI_STATUS               Status;
+
+  SnpMode         = MnpDeviceData->Snp->Mode;
+  NewBufferLength = MnpCalculateBufferLength (SnpMode);
+  NewPaddingSize  = MnpCalculatePaddingSize (SnpMode);
+
+  if (NewBufferLength <= MnpDeviceData->BufferLength) {
+    return EFI_SUCCESS;
+  }
+
+  if (MnpDeviceData->RxNbufCache != NULL) {
+    MnpFreeNbuf (MnpDeviceData, MnpDeviceData->RxNbufCache);
+    MnpDeviceData->RxNbufCache = NULL;
+  }
+
+  if (MnpDeviceData->FreeNbufQue.BufNum != 0) {
+    MnpDeviceData->NbufCnt -= MnpDeviceData->FreeNbufQue.BufNum;
+    NetbufQueFlush (&MnpDeviceData->FreeNbufQue);
+  }
+
+  MnpDeviceData->BufferLength = NewBufferLength;
+  MnpDeviceData->PaddingSize  = NewPaddingSize;
+
+  Status = MnpAddFreeNbuf (MnpDeviceData, MNP_INIT_NET_BUFFER_NUM);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "MnpRefreshBufferPool: MnpAddFreeNbuf failed, %r.\n", Status));
+    return Status;
+  }
+
+  MnpDeviceData->RxNbufCache = MnpAllocNbuf (MnpDeviceData);
+  if (MnpDeviceData->RxNbufCache == NULL) {
+    DEBUG ((DEBUG_ERROR, "MnpRefreshBufferPool: MnpAllocNbuf failed.\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NetbufAllocSpace (
+    MnpDeviceData->RxNbufCache,
+    MnpDeviceData->BufferLength,
+    NET_BUF_TAIL
+    );
+
+  return EFI_SUCCESS;
+}
+
 /**
   Add Count of net buffers to MnpDeviceData->FreeNbufQue. The length of the net
   buffer is specified by MnpDeviceData->BufferLength.
@@ -468,13 +543,13 @@ MnpInitializeDeviceData (
   // from SNP. Do this before fill the FreeNetBufQue.
   //
   //
-  MnpDeviceData->BufferLength = SnpMode->MediaHeaderSize + NET_VLAN_TAG_LEN + SnpMode->MaxPacketSize + NET_ETHER_FCS_SIZE;
+  MnpDeviceData->BufferLength = MnpCalculateBufferLength (SnpMode);
 
   //
   // Make sure the protocol headers immediately following the media header
   // 4-byte aligned, and also preserve additional space for VLAN tag
   //
-  MnpDeviceData->PaddingSize = ((4 - SnpMode->MediaHeaderSize) & 0x3) + NET_VLAN_TAG_LEN;
+  MnpDeviceData->PaddingSize = MnpCalculatePaddingSize (SnpMode);
 
   //
   // Initialize MAC string which will be used as VLAN configuration variable name
@@ -1216,6 +1291,13 @@ MnpStart (
       Status = MnpStartSnp (MnpDeviceData->Snp);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "MnpStart: MnpStartSnp failed, %r.\n", Status));
+
+        goto ErrorExit;
+      }
+
+      Status = MnpRefreshBufferPool (MnpDeviceData);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "MnpStart: MnpRefreshBufferPool failed, %r.\n", Status));
 
         goto ErrorExit;
       }

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -38,6 +38,12 @@ EFI_MANAGED_NETWORK_CONFIG_DATA  mMnpDefaultConfigData = {
   FALSE
 };
 
+EFI_STATUS
+MnpAddFreeNbuf (
+  IN OUT MNP_DEVICE_DATA  *MnpDeviceData,
+  IN     UINTN            Count
+  );
+
 STATIC
 UINT32
 MnpCalculateBufferLength (


### PR DESCRIPTION
### Motivation

- Some environments (simulators) populate `EFI_SIMPLE_NETWORK_MODE` fields only after `Snp->Start`/`Snp->Initialize`, which can make the early computed receive `BufferLength` too small and cause allocation/receive failures or `EFI_BUFFER_TOO_SMALL`/size-check errors.
- The change ensures receive buffers are (re)computed and the NET_BUF pool refreshed after SNP initialization so RX buffers match the real MTU/frame size.

### Description

- Add helper functions `MnpCalculateBufferLength` and `MnpCalculatePaddingSize` to centralize buffer/padding size computation based on `Snp->Mode`.
- Add `MnpRefreshBufferPool` which flushes the existing free NET_BUF queue, frees the cached RX `NET_BUF`, recomputes sizes, re-allocates the pool, and creates a properly sized `RxNbufCache`.
- Use the new helpers during initial device setup (`MnpInitializeDeviceData`) and call `MnpRefreshBufferPool` after `MnpStartSnp` in `MnpStart` so the pool is refreshed when SNP has been started/initialized.
- Update `NetworkPkg/MnpDxe/MnpConfig.c` to incorporate these helpers and the refresh logic, and add debug messages on failure paths.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f26e76ddc8331be0f071fd21f90fc)